### PR TITLE
README.md: Fix indentation of sample codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,26 @@ functional programming languages.
 
 In Streem, simple `cat` program is like this:
 
-   STDIN | STDOUT
+    STDIN | STDOUT
 
 And simple FizzBuzz will be like this:
 
-   ```
-   seq(100) | {|x|
-    if x % 15 == 0 {
-      "FizzBuzz"
-    }
-    else if x % 3 == 0 {
-      "Fizz"
-    }
-    else if x % 5 == 0 {
-      "Buzz"
-    }
-    else {
-      x
-    }
-   } | STDOUT
-   ```
+```
+seq(100) | {|x|
+ if x % 15 == 0 {
+   "FizzBuzz"
+ }
+ else if x % 3 == 0 {
+   "Fizz"
+ }
+ else if x % 5 == 0 {
+   "Buzz"
+ }
+ else {
+   x
+ }
+} | STDOUT
+```
 
 # Note
 
@@ -33,10 +33,10 @@ Stream is still under design stage. It's not working yet.  Stay tuned.
 
 # How to compile
 
-  ```
-  cd src
-  make
-  ```
+```
+cd src
+make
+```
 
 # License
 


### PR DESCRIPTION
The line `STDIN | STDOUT` needs one more space to be rendered as `<pre>`.
