### PR TITLE
Fix copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make
 
 Streem is distributed under MIT license.
 
-Copyright (c) 2015 Yukihiro Matsumoto
+Copyright (c) 2014 Yukihiro Matsumoto
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
It's not 2015 quite yet, so the copyright notice should match the
LICENSE file and be dated as 2014.

Signed-off-by: David Celis me@davidcel.is
