### PR TITLE
Use system default compiler instead of unconditionally using gcc (FreeBSD compatibility)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,5 @@
 YACC = yacc
 LEX = flex
-CC = gcc
 
 all : streem
 


### PR DESCRIPTION
Unconditionally doing CC=gcc breaks on latest FreeBSD versions.
