### PR TITLE
Don't make bin dir if it exists.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ parse.o : y.tab.c lex.yy.c
 	$(CC) -g -c y.tab.c -o parse.o
 
 $(TARGET) : parse.o
-	mkdir `dirname $(TARGET)`
+	mkdir -p `dirname $(TARGET)`
 	$(CC) -g parse.o -o $(TARGET)
 
 clean :


### PR DESCRIPTION
mkdir `dirname ../bin/streem` command raises an error if bin directory exists.

```
$ make
mkdir `dirname ../bin/streem`
cc -g parse.o -o ../bin/streem
$ make clean
rm -f y.output y.tab.c
rm -f lex.yy.c
rm -f *.o ../bin/streem
$ make
bison -y parse.y
flex lex.l
cc -g -c y.tab.c -o parse.o
mkdir `dirname ../bin/streem`
mkdir: ../bin: File exists
make: *** [../bin/streem] Error 1
```
