### PR TITLE
Don't use bison-bridge

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -4,7 +4,10 @@
 ** See Copyright Notice in LICENSE file.
 */
 
-%option bison-bridge
+%{
+#define YY_DECL    int yylex(YYSTYPE *yylval)
+%}
+
 %option noyywrap
 
 TRAIL  [\t \n]*


### PR DESCRIPTION
Some flex implementation doesn't handle `%bison-bridge` pragma.
According to the doc, below is a equivalent to `%bison-bridge`.

http://sector7.xray.aps.anl.gov/~dohnarms/programming/flex/html/Bison-Bridge.html
