### PR TITLE
Remove op_lasgn and op_rasgn.

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -27,8 +27,6 @@ TRAIL  [\t \n]*
 "||"{TRAIL}	return op_or;
 "|"{TRAIL}	return op_bar;
 "&"{TRAIL}	return op_amper;
-"<-"{TRAIL}	return op_lasgn;
-"->"{TRAIL}	return op_rasgn;
 
 if{TRAIL}	return keyword_if;
 {TRAIL}else{TRAIL}	return keyword_else;

--- a/src/parse.y
+++ b/src/parse.y
@@ -35,8 +35,6 @@ static void yyerror(parser_state *p, const char *s);
         keyword_nil
         keyword_true
         keyword_false
-	op_lasgn
-	op_rasgn
         op_plus
         op_minus
         op_mult
@@ -90,8 +88,6 @@ stmts           : /* none */
                 ;
 
 stmt            : var '=' expr
-                | var op_lasgn expr
-                | expr op_rasgn var
                 | keyword_emit opt_args
                 | keyword_return opt_args
                 | keyword_break


### PR DESCRIPTION
Simplify syntax by removing "[var] <- [expr]" and "[expr] -> [var]".
