### PR TITLE
Improve yyerror messages

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -41,6 +41,7 @@ strndup0(const char *s, size_t n)
 %}
 
 %option noyywrap
+%option yylineno
 
 TRAIL  ([\t \n]|"#"[^\n]*"\n")*
 %%

--- a/src/parse.y
+++ b/src/parse.y
@@ -199,7 +199,7 @@ static void
 yyerror(parser_state *p, const char *s)
 {
   p->nerr++;
-  fprintf(stderr, "%s\n", s);
+  fprintf(stderr, "%d: %s around \"%s\"\n", yylineno, s, yytext);
 }
 
 static int


### PR DESCRIPTION
Syntax error messages should show position of the error.
Add line number information and the error token.
