### PR TITLE
Ignore GNU global tag files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 /.git
 a.out
 cscope.out
+GPATH
+GRTAGS
+GTAGS
 /src/y.tab.c
 /src/lex.yy.c
 /src/parse.tab.c


### PR DESCRIPTION
In addition to cscope.out, global tag files should be ignored.