### PR TITLE
Rename prototype target to streem_proto

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+streem_proto

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-TARGET = a.out
+TARGET = streem_proto
 ifeq (Windows_NT,$(OS))
 TARGET:=$(TARGET).exe
 endif


### PR DESCRIPTION
`a.out` is a pretty boring name for an executable. I called it `streem_proto` instead of `streem` because this is a prototype. If you would prefer a different name, please let me know.