### PR TITLE
Add some missing nodes

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -50,9 +50,18 @@ if{TRAIL}           LEX_RETURN(keyword_if);
 break{TRAIL}        LEX_RETURN(keyword_break);
 emit{TRAIL}         LEX_RETURN(keyword_emit);
 return{TRAIL}       LEX_RETURN(keyword_return);
-nil{TRAIL}          LEX_RETURN(keyword_nil);
-true{TRAIL}         LEX_RETURN(keyword_true);
-false{TRAIL}        LEX_RETURN(keyword_false);
+nil{TRAIL} {
+  lval->nd = node_nil();
+  LEX_RETURN(keyword_nil);
+}
+true{TRAIL} {
+  lval->nd = node_true();
+  LEX_RETURN(keyword_true);
+}
+false{TRAIL} {
+  lval->nd = node_false();
+  LEX_RETURN(keyword_false);
+}
 
 [A-Za-z_][A-Za-z0-9_]* {
   lval->id = node_ident_of(yytext);

--- a/src/node.c
+++ b/src/node.c
@@ -54,6 +54,15 @@ node_array_new()
   return node;
 }
 
+strm_node*
+node_array_of(strm_node* node)
+{
+  if (node == NULL)
+    node = node_array_new();
+  node->type = STRM_NODE_VALUE;
+  return node;
+}
+
 void
 node_array_add(strm_node* arr, strm_node* node)
 {
@@ -137,4 +146,25 @@ node_ident_of(const char* s)
 {
   /* TODO: get id of the identifier which named as s */
   return (strm_id) s;
+}
+
+strm_node*
+node_nil()
+{
+  static strm_node node = { STRM_NODE_VALUE, { STRM_VALUE_NIL, {0} } };
+  return &node;
+}
+
+strm_node*
+node_true()
+{
+  static strm_node node = { STRM_NODE_VALUE, { STRM_VALUE_BOOL, {1} } };
+  return &node;
+}
+
+strm_node*
+node_false()
+{
+  static strm_node node = { STRM_NODE_VALUE, { STRM_VALUE_BOOL, {0} } };
+  return &node;
 }

--- a/src/node.c
+++ b/src/node.c
@@ -48,8 +48,8 @@ node_array_new()
   arr->data = NULL;
 
   strm_node* node = malloc(sizeof(strm_node));
-  node->type = STRM_NODE_ARRAY;
-  node->value.t = STRM_VALUE_CARRAY;
+  node->type = STRM_NODE_VALUE;
+  node->value.t = STRM_VALUE_ARRAY;
   node->value.v.p = arr;
   return node;
 }
@@ -59,7 +59,6 @@ node_array_of(strm_node* node)
 {
   if (node == NULL)
     node = node_array_new();
-  node->type = STRM_NODE_VALUE;
   return node;
 }
 
@@ -77,24 +76,100 @@ node_array_add(strm_node* arr, strm_node* node)
 }
 
 strm_node*
-node_let_new(strm_node* var, strm_node* node)
+node_pair_new(strm_node* key, strm_node* value)
 {
-  /* TODO */
-  return NULL;
+  strm_pair* pair = malloc(sizeof(strm_pair));
+  pair->key = key;
+  pair->value = value;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_PAIR;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = pair;
+  return node;
 }
 
 strm_node*
-node_op_new(const char* op, strm_node* lhs, strm_node* rhs)
+node_map_new()
 {
-  /* TODO */
-  return NULL;
+  strm_array* arr = malloc(sizeof(strm_array));
+  /* TODO: error check */
+  arr->len = 0;
+  arr->max = 0;
+  arr->data = NULL;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_VALUE;
+  node->value.t = STRM_VALUE_MAP;
+  node->value.v.p = arr;
+  return node;
 }
 
 strm_node*
-node_funcall_new(strm_id id, strm_node* args, strm_node* blk)
+node_map_of(strm_node* node)
 {
-  /* TODO */
-  return NULL;
+  if (node == NULL)
+    node = node_map_new();
+  return node;
+}
+
+strm_node*
+node_let_new(strm_node* lhs, strm_node* rhs)
+{
+  strm_node_let* node_let = malloc(sizeof(strm_node_let));
+  node_let->lhs = lhs;
+  node_let->rhs = rhs;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_LET;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = node_let;
+  return node;
+}
+
+strm_node*
+node_op_new(char* op, strm_node* lhs, strm_node* rhs)
+{
+  strm_node_op* node_op = malloc(sizeof(strm_node_op));
+  node_op->lhs = lhs;
+  node_op->op = op;
+  node_op->rhs = rhs;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_OP;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = node_op;
+  return node;
+}
+
+strm_node*
+node_func_new(strm_node* ident, strm_node* args, strm_node* blk)
+{
+  strm_node_func* node_func = malloc(sizeof(strm_node_func));
+  node_func->ident = ident;
+  node_func->args = args;
+  node_func->blk = blk;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_FUNC;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = node_func;
+  return node;
+}
+
+strm_node*
+node_call_new(strm_node* cond, strm_node* ident, strm_node* args)
+{
+  strm_node_call* node_call = malloc(sizeof(strm_node_call));
+  node_call->cond = cond;
+  node_call->ident = ident;
+  node_call->args = args;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_CALL;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = node_call;
+  return node;
 }
 
 strm_node*
@@ -142,7 +217,7 @@ node_ident_new(strm_id id)
 }
 
 strm_id
-node_ident_of(const char* s)
+node_ident_of(char* s)
 {
   /* TODO: get id of the identifier which named as s */
   return (strm_id) s;
@@ -166,5 +241,48 @@ strm_node*
 node_false()
 {
   static strm_node node = { STRM_NODE_VALUE, { STRM_VALUE_BOOL, {0} } };
+  return &node;
+}
+
+strm_node*
+node_if_new(strm_node* cond, strm_node* compstmt, strm_node* opt_else)
+{
+  strm_node_if* node_if = malloc(sizeof(strm_node_if));
+  node_if->cond = cond;
+  node_if->compstmt = compstmt;
+  node_if->opt_else = opt_else;
+
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_IF;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = node_if;
+  return node;
+}
+
+
+strm_node*
+node_emit_new(strm_node* value)
+{
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_EMIT;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = value;
+  return node;
+}
+
+strm_node*
+node_return_new(strm_node* value)
+{
+  strm_node* node = malloc(sizeof(strm_node));
+  node->type = STRM_NODE_RETURN;
+  node->value.t = STRM_VALUE_USER;
+  node->value.v.p = value;
+  return node;
+}
+
+strm_node*
+node_break_new(strm_node* value)
+{
+  static strm_node node = { STRM_NODE_BREAK };
   return &node;
 }

--- a/src/parse.y
+++ b/src/parse.y
@@ -61,6 +61,9 @@ static void yyerror(parser_state *p, const char *s);
 %token
         lit_number
         lit_string
+        lit_true
+        lit_false
+        lit_nil
         identifier
 
 /*
@@ -331,11 +334,9 @@ args            : expr
 
 primary0        : lit_number
                     {
-                      /* TODO */
                     }
                 | lit_string
                     {
-                      /* TODO */
                     }
                 | identifier
                     {
@@ -347,11 +348,11 @@ primary0        : lit_number
                     }
                 | '[' args ']'
                     {
-                      /* TODO */
+                      $$ = node_array_of($2);
                     }
                 | '[' ']'
                     {
-                      /* TODO */
+                      $$ = node_array_of(NULL);
                     }
                 | '[' map_args ']'
                     {
@@ -367,15 +368,12 @@ primary0        : lit_number
                     }
                 | keyword_nil
                     {
-                      /* TODO */
                     }
                 | keyword_true
                     {
-                      /* TODO */
                     }
                 | keyword_false
                     {
-                      /* TODO */
                     }
                 ;
 
@@ -509,6 +507,18 @@ dump_node(strm_node* node, int indent) {
       break;
     case STRM_VALUE_STRING:
       printf("VALUE(STRING): %s\n", node->value.v.s);
+      break;
+    case STRM_VALUE_BOOL:
+      printf("VALUE(BOOL): %s\n", node->value.v.i ? "true" : "false");
+      break;
+    case STRM_VALUE_NIL:
+      printf("VALUE(NIL): nil\n");
+      break;
+    case STRM_VALUE_CARRAY:
+      printf("VALUE(ARRAY): []\n");
+      break;
+    default:
+      printf("VALUE(UNKNOWN): %p\n", node->value.v.p);
       break;
     }
     break;

--- a/src/parse.y
+++ b/src/parse.y
@@ -18,7 +18,8 @@
 
 %type <nd> program compstmt
 %type <nd> stmt expr condition block cond var primary primary0
-%type <nd> stmts args opt_args opt_block f_args
+%type <nd> stmts args opt_args opt_block f_args map map_args
+%type <nd> opt_else opt_elsif
 %type <id> identifier
 
 %pure-parser
@@ -105,6 +106,7 @@ stmts           :
                     }
                 | stmts terms stmt
                     {
+                      $$ = $1;
                       node_array_add($1, $3);
                     }
                 | error stmt
@@ -119,15 +121,15 @@ stmt            : var '=' expr
                     }
                 | keyword_emit opt_args
                     {
-                       /* TODO */
+                      $$ = node_emit_new($2);
                     }
                 | keyword_return opt_args
                     {
-                      /* TODO */
+                      $$ = node_return_new($2);
                     }
                 | keyword_break
                     {
-                      /* TODO */
+                      $$ = node_break_new();
                     }
                 | expr
                     {
@@ -137,6 +139,7 @@ stmt            : var '=' expr
 
 var             : identifier
                     {
+                        $$ = node_ident_new($1);
                     }
                 ;
 
@@ -305,11 +308,23 @@ condition       : condition op_plus condition
                 ;
 
 opt_elsif       : /* none */
+                    {
+                      $$ = NULL;
+                    }
                 | opt_elsif keyword_else keyword_if condition '{' compstmt '}'
+                    {
+                      $$ = node_if_new($4, $6, NULL);
+                    }
                 ;
 
 opt_else        : opt_elsif
+                    {
+                      $$ = NULL;
+                    }
                 | opt_elsif keyword_else '{' compstmt '}'
+                    {
+                      $$ = $4;
+                    }
                 ;
 
 opt_args        : /* none */
@@ -325,26 +340,30 @@ opt_args        : /* none */
 args            : expr
                     {
                       $$ = node_array_new();
+                      node_array_add($$, $1);
                     }
                 | args ',' expr
                     {
+                      $$ = $1;
                       node_array_add($1, $3);
                     }
                 ;
 
 primary0        : lit_number
                     {
+                      $$ = $<nd>1;
                     }
                 | lit_string
                     {
-                    }
+                      $$ = $<nd>1;
+					}
                 | identifier
                     {
-                      $$ = node_ident_new($1);
+                      $$ = $<nd>1;
                     }
                 | '(' expr ')'
                     {
-                      /* TODO */
+                       $$ = $2;
                     }
                 | '[' args ']'
                     {
@@ -356,7 +375,7 @@ primary0        : lit_number
                     }
                 | '[' map_args ']'
                     {
-                      /* TODO */
+                      $$ = node_map_of($2);
                     }
                 | '[' ':' '}'
                     {
@@ -364,7 +383,7 @@ primary0        : lit_number
                     }
                 | keyword_if condition '{' compstmt '}' opt_else
                     {
-                      /* TODO */
+                      $$ = node_if_new($2, $4, $6);
                     }
                 | keyword_nil
                     {
@@ -383,36 +402,61 @@ cond            : primary0
                     }
                 | identifier '(' opt_args ')'
                     {
-                      $$ = node_funcall_new($1, $3, NULL);
+                      $$ = node_call_new(NULL, node_ident_new($1), $3);
                     }
                 | cond '.' identifier '(' opt_args ')'
+                    {
+                      $$ = node_call_new(NULL, node_ident_new($3), $5);
+                    }
                 | cond '.' identifier
+                    {
+                      $$ = node_call_new($1, node_ident_new($3), NULL);
+                    }
                 ;
 
 primary         : primary0
-                    {
-                       $$ = $1;
-                    }
                 | block
                     {
+                      $$ = node_func_new(NULL, NULL, $1);
                     }
                 | identifier block
                     {
+                      $$ = node_func_new(node_ident_new($1), NULL, $2);
                     }
                 | identifier '(' opt_args ')' opt_block
                     {
-                      $$ = node_funcall_new($1, $3, $5);
+                      $$ = node_func_new(node_ident_new($1), $3, $5);
                     }
                 | primary '.' identifier '(' opt_args ')' opt_block
+                    {
+                      /* TODO */
+                    }
                 | primary '.' identifier opt_block
+                    {
+                      /* TODO */
+                    }
                 ;
 
 map             : lit_string ':' expr
+                    {
+                      $$ = node_pair_new($<nd>1, $3);
+                    }
                 | identifier ':' expr
+                    {
+                      $$ = node_pair_new(node_ident_new($1), $3);
+                    }
                 ;
 
 map_args        : map
+                    {
+                      $$ = node_map_new();
+                      node_array_add($$, $1);
+                    }
                 | map_args ',' map
+                    {
+                      $$ = $1;
+                      node_array_add($$, $3);
+                    }
                 ;
 
 opt_block       : /* none */
@@ -431,7 +475,7 @@ block           : '{' bparam compstmt '}'
                     }
                 | '{' compstmt '}'
                     {
-                      /* TODO */
+                      $$ = $2;
                     }
                 ;
 
@@ -448,10 +492,12 @@ bparam          : op_rasgn
 f_args          : identifier
                     {
                       $$ = node_array_new();
+                      node_array_add($$, node_ident_new($1));
                     }
                 | f_args ',' identifier
                     {
-                      node_array_add($$, $1);
+                      $$ = $1;
+                      node_array_add($$, node_ident_new($3));
                     }
                 ;
 
@@ -486,16 +532,62 @@ yyerror(parser_state *p, const char *s)
 static void
 dump_node(strm_node* node, int indent) {
   int i;
-  if (!node) return;		  
   for (i = 0; i < indent; i++)
     putchar(' ');
+
+  if (!node) {
+    printf("NIL\n");
+    return;		  
+  }
+
   switch (node->type) {
-  case STRM_NODE_ARRAY:
+  case STRM_NODE_ARGS:
     {
       strm_array* arr0 = node->value.v.p;
       for (i = 0; i < arr0->len; i++)
         dump_node(arr0->data[i], indent+1);
     }
+    break;
+  case STRM_NODE_IF:
+    {
+      printf("IF:\n");
+      dump_node(((strm_node_if*)node->value.v.p)->cond, indent+1);
+      for (i = 0; i < indent; i++)
+        putchar(' ');
+      printf("THEN:\n");
+      dump_node(((strm_node_if*)node->value.v.p)->compstmt, indent+1);
+      strm_node* opt_else = ((strm_node_if*)node->value.v.p)->opt_else;
+      if (opt_else != NULL) {
+        for (i = 0; i < indent; i++)
+          putchar(' ');
+        printf("ELSE:\n");
+        dump_node(opt_else, indent+1);
+      }
+    }
+    break;
+  case STRM_NODE_EMIT:
+    printf("EMIT:\n");
+    dump_node((strm_node*) node->value.v.p, indent);
+    break;
+  case STRM_NODE_OP:
+    printf("OP:\n");
+    dump_node(((strm_node_op*) node->value.v.p)->lhs, indent+1);
+    for (i = 0; i < indent+1; i++)
+      putchar(' ');
+    puts(((strm_node_op*) node->value.v.p)->op);
+    dump_node(((strm_node_op*) node->value.v.p)->rhs, indent+1);
+    break;
+  case STRM_NODE_FUNC:
+    printf("FUNC:\n");
+    dump_node(((strm_node_func*) node->value.v.p)->ident, indent+1);
+    dump_node(((strm_node_func*) node->value.v.p)->args, indent+1);
+    dump_node(((strm_node_func*) node->value.v.p)->blk, indent+1);
+    break;
+  case STRM_NODE_CALL:
+    printf("CALL:\n");
+    dump_node(((strm_node_call*) node->value.v.p)->cond, indent+2);
+    dump_node(((strm_node_call*) node->value.v.p)->ident, indent+2);
+    dump_node(((strm_node_call*) node->value.v.p)->args, indent+2);
     break;
   case STRM_NODE_IDENT:
     printf("IDENT: %d\n", node->value.v.id);
@@ -514,8 +606,25 @@ dump_node(strm_node* node, int indent) {
     case STRM_VALUE_NIL:
       printf("VALUE(NIL): nil\n");
       break;
-    case STRM_VALUE_CARRAY:
-      printf("VALUE(ARRAY): []\n");
+    case STRM_VALUE_ARRAY:
+      printf("VALUE(ARRAY):\n");
+      {
+        strm_array* arr0 = node->value.v.p;
+        for (i = 0; i < arr0->len; i++)
+          dump_node(arr0->data[i], indent+1);
+      }
+      break;
+    case STRM_VALUE_MAP:
+      printf("VALUE(MAP):\n");
+      {
+        strm_array* arr0 = node->value.v.p;
+        for (i = 0; i < arr0->len; i++) {
+          strm_node* pair = arr0->data[i];
+		  strm_pair* pair0 = pair->value.v.p;
+          dump_node(pair0->key, indent+1);
+          dump_node(pair0->value, indent+1);
+        }
+      }
       break;
     default:
       printf("VALUE(UNKNOWN): %p\n", node->value.v.p);

--- a/src/strm.h
+++ b/src/strm.h
@@ -5,28 +5,31 @@
 
 typedef enum {
   STRM_VALUE_BOOL,
-  STRM_VALUE_CARRAY,
   STRM_VALUE_ARRAY,
   STRM_VALUE_MAP,
   STRM_VALUE_STRING,
   STRM_VALUE_DOUBLE,
   STRM_VALUE_FIXNUM,
   STRM_VALUE_NIL,
+  STRM_VALUE_USER,
 } strm_value_type;
 
 typedef enum {
-  STRM_NODE_ARRAY,
+  STRM_NODE_ARGS,
+  STRM_NODE_PAIR,
   STRM_NODE_VALUE,
   STRM_NODE_BLOCK,
   STRM_NODE_IDENT,
   STRM_NODE_LET,
   STRM_NODE_IF,
-  STRM_NODE_ELSE,
-  STRM_NODE_ELSEIF,
+  STRM_NODE_EMIT,
+  STRM_NODE_RETURN,
+  STRM_NODE_BREAK,
   STRM_NODE_VAR,
   STRM_NODE_CONST,
-  STRM_NODE_OP_PLUS,
-  STRM_NODE_OP_MINUS,
+  STRM_NODE_OP,
+  STRM_NODE_FUNC,
+  STRM_NODE_CALL,
 } strm_node_type;
 
 typedef intptr_t strm_id;
@@ -51,10 +54,44 @@ typedef struct {
 } strm_node;
 
 typedef struct {
+  strm_node* key;
+  strm_node* value;
+} strm_pair;
+
+typedef struct {
   int len;
   int max;
   strm_node** data;
 } strm_array;
+
+typedef struct {
+  strm_node* cond;
+  strm_node* compstmt;
+  strm_node* opt_else;
+} strm_node_if;
+
+typedef struct {
+  strm_node* lhs;
+  strm_node* rhs;
+} strm_node_let;
+
+typedef struct {
+  strm_node* lhs;
+  char* op;
+  strm_node* rhs;
+} strm_node_op;
+
+typedef struct {
+  strm_node* ident;
+  strm_node* args;
+  strm_node* blk;
+} strm_node_func;
+
+typedef struct {
+  strm_node* cond;
+  strm_node* ident;
+  strm_node* args;
+} strm_node_call;
 
 typedef struct parser_state {
   int nerr;
@@ -68,14 +105,22 @@ extern strm_node* node_value_new(strm_node*);
 extern strm_node* node_array_new();
 extern strm_node* node_array_of(strm_node*);
 extern void node_array_add(strm_node*, strm_node*);
+extern strm_node* node_pair_new(strm_node*, strm_node*);
+extern strm_node* node_map_new();
+extern strm_node* node_map_of(strm_node*);
 extern strm_node* node_let_new(strm_node*, strm_node*);
-extern strm_node* node_op_new(const char*, strm_node*, strm_node*);
-extern strm_node* node_funcall_new(strm_id, strm_node*, strm_node*);
+extern strm_node* node_op_new(char*, strm_node*, strm_node*);
+extern strm_node* node_func_new(strm_node*, strm_node*, strm_node*);
+extern strm_node* node_call_new(strm_node*, strm_node*, strm_node*);
 extern strm_node* node_double_new(strm_double);
 extern strm_node* node_string_new(strm_string);
 extern strm_node* node_string_len_new(strm_string, size_t);
+extern strm_node* node_if_new(strm_node*, strm_node*, strm_node*);
+extern strm_node* node_emit_new(strm_node*);
+extern strm_node* node_return_new(strm_node*);
+extern strm_node* node_break_new();
 extern strm_node* node_ident_new(strm_id);
-extern strm_id node_ident_of(const char*);
+extern strm_id node_ident_of(char*);
 extern strm_node* node_nil();
 extern strm_node* node_true();
 extern strm_node* node_false();

--- a/src/strm.h
+++ b/src/strm.h
@@ -66,6 +66,7 @@ typedef struct parser_state {
 
 extern strm_node* node_value_new(strm_node*);
 extern strm_node* node_array_new();
+extern strm_node* node_array_of(strm_node*);
 extern void node_array_add(strm_node*, strm_node*);
 extern strm_node* node_let_new(strm_node*, strm_node*);
 extern strm_node* node_op_new(const char*, strm_node*, strm_node*);
@@ -75,4 +76,7 @@ extern strm_node* node_string_new(strm_string);
 extern strm_node* node_string_len_new(strm_string, size_t);
 extern strm_node* node_ident_new(strm_id);
 extern strm_id node_ident_of(const char*);
+extern strm_node* node_nil();
+extern strm_node* node_true();
+extern strm_node* node_false();
 #endif /* _STRM_H_ */


### PR DESCRIPTION
**test.strm**
```
if 1 {
  true
} else {
  false
}
if 1 < 2 {
  true
}
emit 1

foo {
 "foo"
}

foo(1)

["foo": "bar"]
```

```
$ cat test.strm | ./bin/streem
test.strm: Syntax OK
---------
VALUE(ARRAY):
 IF:
  VALUE(NUMBER): 1.000000
 THEN:
  VALUE(ARRAY):
   VALUE(BOOL): true
 ELSE:
  VALUE(ARRAY):
   VALUE(BOOL): false
 IF:
  OP:
   VALUE(NUMBER): 1.000000
   <
   VALUE(NUMBER): 2.000000
 THEN:
  VALUE(ARRAY):
   VALUE(BOOL): true
 EMIT:
 VALUE(ARRAY):
  VALUE(NUMBER): 1.000000
 FUNC:
  IDENT: 8992253
  NIL
  VALUE(ARRAY):
   VALUE(STRING): foo
 FUNC:
  IDENT: 8992269
  VALUE(ARRAY):
   VALUE(NUMBER): 1.000000
  NIL
 VALUE(MAP):
  VALUE(STRING): foo
  VALUE(STRING): bar
```

currently ident `foo` doesn't match in definition/call. because id is pointer of the string.
