### PR TITLE
Fix definition of block and call

### DIFF
--- a/src/lex.l
+++ b/src/lex.l
@@ -7,6 +7,7 @@
 %{
 #include <string.h>
 #include "strm.h"
+#include "node.h"
 
 #define YY_DECL    int yylex(YYSTYPE *lval, parser_state *p)
 

--- a/src/node.c
+++ b/src/node.c
@@ -143,27 +143,27 @@ node_op_new(char* op, strm_node* lhs, strm_node* rhs)
 }
 
 strm_node*
-node_func_new(strm_node* ident, strm_node* args, strm_node* blk)
+node_block_new(strm_node* args, strm_node* compstmt)
 {
-  strm_node_func* node_func = malloc(sizeof(strm_node_func));
-  node_func->ident = ident;
-  node_func->args = args;
-  node_func->blk = blk;
+  strm_node_block* node_block = malloc(sizeof(strm_node_block));
+  node_block->args = args;
+  node_block->compstmt = compstmt;
 
   strm_node* node = malloc(sizeof(strm_node));
-  node->type = STRM_NODE_FUNC;
+  node->type = STRM_NODE_BLOCK;
   node->value.t = STRM_VALUE_USER;
-  node->value.v.p = node_func;
+  node->value.v.p = node_block;
   return node;
 }
 
 strm_node*
-node_call_new(strm_node* cond, strm_node* ident, strm_node* args)
+node_call_new(strm_node* cond, strm_node* ident, strm_node* args, strm_node* blk)
 {
   strm_node_call* node_call = malloc(sizeof(strm_node_call));
   node_call->cond = cond;
   node_call->ident = ident;
   node_call->args = args;
+  node_call->blk = blk;
 
   strm_node* node = malloc(sizeof(strm_node));
   node->type = STRM_NODE_CALL;

--- a/src/node.c
+++ b/src/node.c
@@ -1,4 +1,5 @@
 #include "strm.h"
+#include "node.h"
 #include <string.h>
 
 static char*

--- a/src/node.h
+++ b/src/node.h
@@ -1,0 +1,99 @@
+#ifndef _NODE_H_
+#define _NODE_H_
+
+typedef enum {
+  STRM_NODE_ARGS,
+  STRM_NODE_PAIR,
+  STRM_NODE_VALUE,
+  STRM_NODE_BLOCK,
+  STRM_NODE_IDENT,
+  STRM_NODE_LET,
+  STRM_NODE_IF,
+  STRM_NODE_EMIT,
+  STRM_NODE_RETURN,
+  STRM_NODE_BREAK,
+  STRM_NODE_VAR,
+  STRM_NODE_CONST,
+  STRM_NODE_OP,
+  STRM_NODE_CALL,
+} strm_node_type;
+
+typedef struct {
+  strm_node_type type;
+  strm_value value;
+} strm_node;
+
+typedef struct {
+  strm_node* key;
+  strm_node* value;
+} strm_pair;
+
+typedef struct {
+  int len;
+  int max;
+  strm_node** data;
+} strm_array;
+
+typedef struct {
+  strm_node* cond;
+  strm_node* compstmt;
+  strm_node* opt_else;
+} strm_node_if;
+
+typedef struct {
+  strm_node* lhs;
+  strm_node* rhs;
+} strm_node_let;
+
+typedef struct {
+  strm_node* lhs;
+  char* op;
+  strm_node* rhs;
+} strm_node_op;
+
+typedef struct {
+  strm_node* args;
+  strm_node* compstmt;
+} strm_node_block;
+
+typedef struct {
+  strm_node* cond;
+  strm_node* ident;
+  strm_node* args;
+  strm_node* blk;
+} strm_node_call;
+
+typedef struct parser_state {
+  int nerr;
+  void *lval;
+  const char *fname;
+  int lineno;
+  int tline;
+} parser_state;
+
+extern strm_node* node_value_new(strm_node*);
+extern strm_node* node_array_new();
+extern strm_node* node_array_of(strm_node*);
+extern void node_array_add(strm_node*, strm_node*);
+extern strm_node* node_pair_new(strm_node*, strm_node*);
+extern strm_node* node_map_new();
+extern strm_node* node_map_of(strm_node*);
+extern strm_node* node_let_new(strm_node*, strm_node*);
+extern strm_node* node_op_new(char*, strm_node*, strm_node*);
+extern strm_node* node_block_new(strm_node*, strm_node*);
+extern strm_node* node_call_new(strm_node*, strm_node*, strm_node*, strm_node*);
+extern strm_node* node_double_new(strm_double);
+extern strm_node* node_string_new(strm_string);
+extern strm_node* node_string_len_new(strm_string, size_t);
+extern strm_node* node_if_new(strm_node*, strm_node*, strm_node*);
+extern strm_node* node_emit_new(strm_node*);
+extern strm_node* node_return_new(strm_node*);
+extern strm_node* node_break_new();
+extern strm_node* node_ident_new(strm_id);
+extern strm_id node_ident_of(char*);
+extern strm_node* node_nil();
+extern strm_node* node_true();
+extern strm_node* node_false();
+
+#endif /* _NODE_H_ */
+

--- a/src/parse.y
+++ b/src/parse.y
@@ -18,7 +18,7 @@
 
 %type <nd> program compstmt
 %type <nd> stmt expr condition block cond var primary primary0
-%type <nd> stmts args opt_args opt_block f_args map map_args
+%type <nd> stmts args opt_args opt_block f_args map map_args bparam
 %type <nd> opt_else opt_elsif
 %type <id> identifier
 
@@ -402,38 +402,38 @@ cond            : primary0
                     }
                 | identifier '(' opt_args ')'
                     {
-                      $$ = node_call_new(NULL, node_ident_new($1), $3);
+                      $$ = node_call_new(NULL, node_ident_new($1), $3, NULL);
                     }
                 | cond '.' identifier '(' opt_args ')'
                     {
-                      $$ = node_call_new(NULL, node_ident_new($3), $5);
+                      $$ = node_call_new(NULL, node_ident_new($3), $5, NULL);
                     }
                 | cond '.' identifier
                     {
-                      $$ = node_call_new($1, node_ident_new($3), NULL);
+                      $$ = node_call_new($1, node_ident_new($3), NULL, NULL);
                     }
                 ;
 
 primary         : primary0
                 | block
                     {
-                      $$ = node_func_new(NULL, NULL, $1);
+                      $$ = node_call_new(NULL, NULL, NULL, $1);
                     }
                 | identifier block
                     {
-                      $$ = node_func_new(node_ident_new($1), NULL, $2);
+                      $$ = node_call_new(NULL, node_ident_new($1), NULL, $2);
                     }
                 | identifier '(' opt_args ')' opt_block
                     {
-                      $$ = node_func_new(node_ident_new($1), $3, $5);
+                      $$ = node_call_new(NULL, node_ident_new($1), $3, $5);
                     }
                 | primary '.' identifier '(' opt_args ')' opt_block
                     {
-                      /* TODO */
+                      $$ = node_call_new($1, node_ident_new($3), $5, $7);
                     }
                 | primary '.' identifier opt_block
                     {
-                      /* TODO */
+                      $$ = node_call_new($1, node_ident_new($3), NULL, $4);
                     }
                 ;
 
@@ -471,21 +471,21 @@ opt_block       : /* none */
 
 block           : '{' bparam compstmt '}'
                     {
-                      /* TODO */
+                      $$ = node_block_new($2, $3);
                     }
                 | '{' compstmt '}'
                     {
-                      $$ = $2;
+                      $$ = node_block_new(NULL, $2);
                     }
                 ;
 
 bparam          : op_rasgn
                     {
-                      /* TODO */
+                      $$ = NULL;
                     }
                 | f_args op_rasgn
                     {
-                      /* TODO */
+                      $$ = $1;
                     }
                 ;
 
@@ -577,17 +577,17 @@ dump_node(strm_node* node, int indent) {
     puts(((strm_node_op*) node->value.v.p)->op);
     dump_node(((strm_node_op*) node->value.v.p)->rhs, indent+1);
     break;
-  case STRM_NODE_FUNC:
-    printf("FUNC:\n");
-    dump_node(((strm_node_func*) node->value.v.p)->ident, indent+1);
-    dump_node(((strm_node_func*) node->value.v.p)->args, indent+1);
-    dump_node(((strm_node_func*) node->value.v.p)->blk, indent+1);
+  case STRM_NODE_BLOCK:
+    printf("BLOCK:\n");
+    dump_node(((strm_node_block*) node->value.v.p)->args, indent+1);
+    dump_node(((strm_node_block*) node->value.v.p)->compstmt, indent+1);
     break;
   case STRM_NODE_CALL:
     printf("CALL:\n");
     dump_node(((strm_node_call*) node->value.v.p)->cond, indent+2);
     dump_node(((strm_node_call*) node->value.v.p)->ident, indent+2);
     dump_node(((strm_node_call*) node->value.v.p)->args, indent+2);
+    dump_node(((strm_node_call*) node->value.v.p)->blk, indent+2);
     break;
   case STRM_NODE_IDENT:
     printf("IDENT: %d\n", node->value.v.id);

--- a/src/parse.y
+++ b/src/parse.y
@@ -111,7 +111,6 @@ stmts           :
                     }
                 | error stmt
                     {
-                      /* TODO */
                     }
                 ;
 
@@ -377,9 +376,9 @@ primary0        : lit_number
                     {
                       $$ = node_map_of($2);
                     }
-                | '[' ':' '}'
+                | '[' ':' ']'
                     {
-                      /* TODO */
+                      $$ = node_map_of(NULL);
                     }
                 | keyword_if condition '{' compstmt '}' opt_else
                     {

--- a/src/parse.y
+++ b/src/parse.y
@@ -9,6 +9,7 @@
 #define YYERROR_VERBOSE 1
 
 #include "strm.h"
+#include "node.h"
 %}
 
 %union {

--- a/src/strm.h
+++ b/src/strm.h
@@ -14,23 +14,6 @@ typedef enum {
   STRM_VALUE_USER,
 } strm_value_type;
 
-typedef enum {
-  STRM_NODE_ARGS,
-  STRM_NODE_PAIR,
-  STRM_NODE_VALUE,
-  STRM_NODE_BLOCK,
-  STRM_NODE_IDENT,
-  STRM_NODE_LET,
-  STRM_NODE_IF,
-  STRM_NODE_EMIT,
-  STRM_NODE_RETURN,
-  STRM_NODE_BREAK,
-  STRM_NODE_VAR,
-  STRM_NODE_CONST,
-  STRM_NODE_OP,
-  STRM_NODE_CALL,
-} strm_node_type;
-
 typedef intptr_t strm_id;
 typedef double strm_double;
 typedef char* strm_string;
@@ -47,80 +30,4 @@ typedef struct {
   } v;
 } strm_value;
 
-typedef struct {
-  strm_node_type type;
-  strm_value value;
-} strm_node;
-
-typedef struct {
-  strm_node* key;
-  strm_node* value;
-} strm_pair;
-
-typedef struct {
-  int len;
-  int max;
-  strm_node** data;
-} strm_array;
-
-typedef struct {
-  strm_node* cond;
-  strm_node* compstmt;
-  strm_node* opt_else;
-} strm_node_if;
-
-typedef struct {
-  strm_node* lhs;
-  strm_node* rhs;
-} strm_node_let;
-
-typedef struct {
-  strm_node* lhs;
-  char* op;
-  strm_node* rhs;
-} strm_node_op;
-
-typedef struct {
-  strm_node* args;
-  strm_node* compstmt;
-} strm_node_block;
-
-typedef struct {
-  strm_node* cond;
-  strm_node* ident;
-  strm_node* args;
-  strm_node* blk;
-} strm_node_call;
-
-typedef struct parser_state {
-  int nerr;
-  void *lval;
-  const char *fname;
-  int lineno;
-  int tline;
-} parser_state;
-
-extern strm_node* node_value_new(strm_node*);
-extern strm_node* node_array_new();
-extern strm_node* node_array_of(strm_node*);
-extern void node_array_add(strm_node*, strm_node*);
-extern strm_node* node_pair_new(strm_node*, strm_node*);
-extern strm_node* node_map_new();
-extern strm_node* node_map_of(strm_node*);
-extern strm_node* node_let_new(strm_node*, strm_node*);
-extern strm_node* node_op_new(char*, strm_node*, strm_node*);
-extern strm_node* node_block_new(strm_node*, strm_node*);
-extern strm_node* node_call_new(strm_node*, strm_node*, strm_node*, strm_node*);
-extern strm_node* node_double_new(strm_double);
-extern strm_node* node_string_new(strm_string);
-extern strm_node* node_string_len_new(strm_string, size_t);
-extern strm_node* node_if_new(strm_node*, strm_node*, strm_node*);
-extern strm_node* node_emit_new(strm_node*);
-extern strm_node* node_return_new(strm_node*);
-extern strm_node* node_break_new();
-extern strm_node* node_ident_new(strm_id);
-extern strm_id node_ident_of(char*);
-extern strm_node* node_nil();
-extern strm_node* node_true();
-extern strm_node* node_false();
 #endif /* _STRM_H_ */

--- a/src/strm.h
+++ b/src/strm.h
@@ -28,7 +28,6 @@ typedef enum {
   STRM_NODE_VAR,
   STRM_NODE_CONST,
   STRM_NODE_OP,
-  STRM_NODE_FUNC,
   STRM_NODE_CALL,
 } strm_node_type;
 
@@ -82,15 +81,15 @@ typedef struct {
 } strm_node_op;
 
 typedef struct {
-  strm_node* ident;
   strm_node* args;
-  strm_node* blk;
-} strm_node_func;
+  strm_node* compstmt;
+} strm_node_block;
 
 typedef struct {
   strm_node* cond;
   strm_node* ident;
   strm_node* args;
+  strm_node* blk;
 } strm_node_call;
 
 typedef struct parser_state {
@@ -110,8 +109,8 @@ extern strm_node* node_map_new();
 extern strm_node* node_map_of(strm_node*);
 extern strm_node* node_let_new(strm_node*, strm_node*);
 extern strm_node* node_op_new(char*, strm_node*, strm_node*);
-extern strm_node* node_func_new(strm_node*, strm_node*, strm_node*);
-extern strm_node* node_call_new(strm_node*, strm_node*, strm_node*);
+extern strm_node* node_block_new(strm_node*, strm_node*);
+extern strm_node* node_call_new(strm_node*, strm_node*, strm_node*, strm_node*);
 extern strm_node* node_double_new(strm_double);
 extern strm_node* node_string_new(strm_string);
 extern strm_node* node_string_len_new(strm_string, size_t);


### PR DESCRIPTION
```
foo { x -> "foo" }
```

Should be

```
 CALL:
   NIL (COND)
   IDENT: 8468005 (NOTE: foo)
   NIL (CALL ARGS)
   BLOCK:
    VALUE(ARRAY): (ARGS)
     IDENT: 8468011 (NOTE: x)
    VALUE(ARRAY): (STMTS)
     VALUE(STRING): foo
```
