### PR TITLE
change %d to %ld to suppress cc warning

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -590,7 +590,7 @@ dump_node(strm_node* node, int indent) {
     dump_node(((strm_node_call*) node->value.v.p)->blk, indent+2);
     break;
   case STRM_NODE_IDENT:
-    printf("IDENT: %d\n", node->value.v.id);
+    printf("IDENT: %ld\n", node->value.v.id);
     break;
   case STRM_NODE_VALUE:
     switch (node->value.t) {


### PR DESCRIPTION
`cc` warns about using type `int` where it should actually be of type `long` (`strm_id`). This pull request should suppress that warning.