### PR TITLE
Use PRIdPTR for intptr_t in printf

### DIFF
--- a/src/parse.y
+++ b/src/parse.y
@@ -10,6 +10,7 @@
 
 #include "strm.h"
 #include "node.h"
+#include <inttypes.h>
 %}
 
 %union {
@@ -590,7 +591,7 @@ dump_node(strm_node* node, int indent) {
     dump_node(((strm_node_call*) node->value.v.p)->blk, indent+2);
     break;
   case STRM_NODE_IDENT:
-    printf("IDENT: %ld\n", node->value.v.id);
+    printf("IDENT: %"PRIdPTR"\n", node->value.v.id);
     break;
   case STRM_NODE_VALUE:
     switch (node->value.t) {


### PR DESCRIPTION
PRIdPTR is defined in inttypes.h but there is not inttypes.h and build succeed in OS X.
Just in case  inttypes.h was inserted.

