### PR TITLE
Fix Wformat warning for intptr_t for print conversion

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,7 @@ dump_node(strm_node* node, int indent) {
     dump_node(((strm_node_call*) node->value.v.p)->blk, indent+2);
     break;
   case STRM_NODE_IDENT:
-    printf("IDENT: %d\n", node->value.v.id);
+    printf("IDENT: %ld\n", node->value.v.id);
     break;
   case STRM_NODE_VALUE:
     switch (node->value.t) {


### PR DESCRIPTION
`printf()` expects the `%ld`, not `%d`, specifier for type `intptr_t`/`strm_id`.

Another (not-as-simple) fix I found was replacing the `<stdint.h>` lib in `strm.h` with `<inttypes.h>` lib and use `PRIdPTR` for the specifier. Although it'd just be for a macro, it may be useful later for `printf()`/`scanf()` facilities.
(i.e., `printf("IDENT: %" PRIdPTR "\n", node->value.v.id);`)
* http://www.qnx.com/developers/docs/6.5.0/index.jsp?topic=%2Fcom.qnx.doc.dinkum_en_c99%2Finttypes.html&anchor=PRIdPTR
* http://stackoverflow.com/questions/7597025/difference-between-stdint-h-and-inttypes-h

It's a minor fix, but gets rid of a `-Wformat` warning.