### PR TITLE
Fix 'else'

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -500,7 +500,7 @@ node_expr(strm_ctx* ctx, node* np)
       }
       if (v->t == STRM_VALUE_NIL || v->v.p == NULL ||
           (v->t == STRM_VALUE_STRING && *v->v.s == 0)) {
-        if (nif->opt_else == NULL)
+        if (nif->opt_else != NULL)
           node_expr_stmt(ctx, nif->opt_else);
       } else {
         node_expr_stmt(ctx, nif->compstmt);


### PR DESCRIPTION
OS : OS X (10.9.5)
Compiler : Apple LLVM version 6.0 (clang-600.0.56) (based on LLVM 3.5svn)

Before:
```
$ ./bin/streem 
^D
if 1 == 0 { puts("ok") } else { puts("ng") }    # expect : 'ng'. actual : not displayed.

$ ./bin/streem
if 1 == 0 { puts("ok") }    # expect : not displayed. actual : segmentation fault 
^D
zsh: segmentation fault  ./bin/streem

```

After:

```
$ ./bin/streem     
if 1 == 0 { puts("ok") } else { puts("ng") }
^D
'ng'

$ ./bin/streem
if 1 == 0 { puts("ok") }
^D
```