### PR TITLE
Fixed Typo in Example 4

### DIFF
--- a/examples/04skip.strm
+++ b/examples/04skip.strm
@@ -1,7 +1,7 @@
 # pick even numbers
 seq(100) | {x -> if x % 2 == 1 {skip}; x} | STDOUT
 # output:
-#  1
-#  3
-#  5
+#  2
+#  4
+#  6
 #  :


### PR DESCRIPTION
Example code picks even numbers but the comments describing the output used to show odd numbers