### PR TITLE
fix build on windows, readonly_data_p return TRUE always because IsBadWriterPtr is obsolute API on windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ LIBS = -lpthread
 
 ifeq (Windows_NT,$(OS))
 TARGET:=$(TARGET).exe
+LIBS += -lws2_32
 endif
 
 TESTS=$(wildcard examples/*.strm)

--- a/src/string.c
+++ b/src/string.c
@@ -19,6 +19,13 @@ readonly_data_p(const char *p)
 {
   return (void*)get_etext() < p && p < (void*)get_edata();
 }
+#elif defined(_WIN32)
+
+static inline int
+readonly_data_p(const char *p)
+{
+  return 1;
+}
 #else
 
 extern char _etext[];


### PR DESCRIPTION
...