### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ it will be invoked for each element in the stream.
 
 ## Compiling
 
-### Install dependencies
+### Installing dependencies
 
 * bison
 * flex


### PR DESCRIPTION
Header should not imperative form but noun (it is gerund).

For example, Travis CI blog is:

[Installing Dependencies](http://docs.travis-ci.com/user/installing-dependencies/)