### PR TITLE
Refactor strm_ptr_eq func in src/value.c

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -205,16 +205,14 @@ strm_ptr_eq(struct strm_object *a, struct strm_object *b)
 {
   if (a == b) return TRUE;
   if (a == NULL) return FALSE;
-  else {
-    if (a->type != b->type) return FALSE;
-    switch (a->type) {
-    case STRM_OBJ_ARRAY:
-      return strm_ary_eq((struct strm_array*)a, (struct strm_array*)b);
-    case STRM_OBJ_STRING:
-      return strm_str_eq((struct strm_string*)a, (struct strm_string*)b);
-    default:
-      return FALSE;
-    }
+  if (a->type != b->type) return FALSE;
+  switch (a->type) {
+  case STRM_OBJ_ARRAY:
+    return strm_ary_eq((struct strm_array*)a, (struct strm_array*)b);
+  case STRM_OBJ_STRING:
+    return strm_str_eq((struct strm_string*)a, (struct strm_string*)b);
+  default:
+    return FALSE;
   }
 }
 


### PR DESCRIPTION
`else` is redundant. it is removed.