### PR TITLE
Dockerfile: Use Alpine Linux instead of Debian.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
-FROM debian
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential flex bison libgc-dev
-ADD src/ /usr/src/streem/
-WORKDIR /usr/src/streem
-RUN make
-CMD /usr/src/streem/streem
+##################################
+#       Streem Dockerfile.       #
+# https://github.com/matz/streem #
+##################################
+FROM alpine
+
+COPY . /usr/src/streem
+
+RUN \
+    apk update && \
+    apk add \
+      musl-dev gcc flex \
+      bison gc-dev make \
+    && \
+    cd /usr/src/streem && \
+    make && \
+    apk del --purge \
+        musl-dev gcc flex \
+        bison gc-dev make \
+    && \
+    rm -rf /var/cache/apk/*
+
+CMD /usr/src/streem/bin/streem


### PR DESCRIPTION
Hello.

This commit changes the Dockerfile to use Alpine instead of Debian for size reasons.

I had to change the added src to be the complete repo, otherwise It would try to place the binary in /usr/src/bin/streem, which isn't a good thing.

I am very welcome to comments and I will try to address them.

Greetings,
vifino