### PR TITLE
fix to work 07netcat.strm on windows

### DIFF
--- a/examples/07netcat.strm
+++ b/examples/07netcat.strm
@@ -1,3 +1,3 @@
 s = tcp_socket("localhost", 8007)
-stdin | s
 s | stdout
+stdin | s

--- a/src/io.c
+++ b/src/io.c
@@ -6,6 +6,7 @@
 # include <sys/socket.h>
 #else
 # include <ws2tcpip.h>
+# include <fcntl.h>
 #endif
 #include <sys/stat.h>
 
@@ -334,7 +335,7 @@ strm_writeio(strm_io io)
 #ifdef _WIN32
     WSANETWORKEVENTS wev;
     if (WSAEnumNetworkEvents((SOCKET) io->fd, NULL, &wev) == 0) {
-      d->f = fdopen(_open_osfhandle(io->fd, 0), "w");
+      d->f = fdopen(_open_osfhandle(io->fd, _O_RDONLY), "w");
     } else
       d->f = fdopen(io->fd, "w");
 #else

--- a/src/pollfd.c
+++ b/src/pollfd.c
@@ -186,7 +186,6 @@ epoll_wait(int epfd, struct epoll_event* events, int maxevents, int timeout)
       } else {
         HANDLE h = (HANDLE) _get_osfhandle(ee->fds[i]);
         if (h != INVALID_HANDLE_VALUE && WaitForSingleObject(h, 0) == WAIT_OBJECT_0) {
-          memcpy(&events[e++], ee, sizeof(struct epoll_event));
           events[e++] = *ee;
           if (ee->events & EPOLLONESHOT)
             ee->fds[i] = -1;

--- a/src/socket.c
+++ b/src/socket.c
@@ -149,8 +149,10 @@ tcp_socket(strm_stream* task, int argc, strm_value* args, strm_value* ret)
   strm_string host;
 
 #ifdef _WIN32
+  int sockopt = SO_SYNCHRONOUS_NONALERT;
   WSADATA wsa;
   WSAStartup(MAKEWORD(2, 0), &wsa);
+  setsockopt(INVALID_SOCKET, SOL_SOCKET, SO_OPENTYPE, (char *)&sockopt, sizeof(sockopt));
 #endif
 
   if (argc != 2) {


### PR DESCRIPTION
I modifed order of streming in 07netcat.strm because windows can't poll stdin in non-main thread. it should poll input with ReadConsoleInput or ReadFile. So this is a temporary workaround .
