### PR TITLE
array accessor fix

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -489,12 +489,14 @@ exec_call(strm_stream* strm, strm_state* state, strm_string name, int argc, strm
   if (argc > 0) {
     strm_state* ns = strm_value_ns(argv[0]);
     if (ns) {
-      n = strm_var_get(ns, name, &m);
-    }
-    else if (argc == 1 && strm_array_p(argv[0])) {
-      m = strm_str_value(name);
-      n = ary_get(strm, argv[0], 1, &m, ret);
-      if (n == STRM_OK) return STRM_OK;
+      if (ns == strm_ns_array && argc == 1 && strm_array_p(argv[0])) {
+        m = strm_str_value(name);
+        n = ary_get(strm, argv[0], 1, &m, ret);
+        if (n == STRM_OK) return STRM_OK;
+      }
+      else {
+        n = strm_var_get(ns, name, &m);
+      }
     }
   }
   if (n == STRM_NG) {


### PR DESCRIPTION
Hi.
It seems that array accessor haven't worked since the commit e5649d3e244682428738ede17fac5e10c30e2df5.

I executed the below code;
```
fread("items.csv")|csv()|filter{x->x.price > 100}|stdout
```
with the below csv;
```
id,name,price
0,apple,90
1,banana,110
2,grape,200
```
then, I got a segfault message...
I think that the output should be the following;
```
[id:1, name:"banana", price:110]
[id:2, name:"grape", price:200]
```
Probably, the problem is caused because strm_value_ns() function no longer returns NULL in case of strm_array.
I fixed it.