### PR TITLE
Allow reduce for non integer result

### DIFF
--- a/src/iter.c
+++ b/src/iter.c
@@ -524,7 +524,7 @@ reduce_finish(strm_stream* strm, strm_value data)
   struct reduce_data* d = strm->data;
 
   if (!d->init) return STRM_NG;
-  strm_emit(strm, strm_int_value(d->acc), NULL);
+  strm_emit(strm, d->acc, NULL);
   return STRM_OK;
 }
 


### PR DESCRIPTION
### Before

```
["a", "b", "c"] | reduce {acc, c -> acc + c } | stdout
# => 1946159680
```

### After

```
["a", "b", "c"] | reduce {acc, c -> acc + c } | stdout
# => abc
```