### PR TITLE
Early stage prototype of *spawn* function (producer stream, only).

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -11,6 +11,7 @@ void strm_kvs_init(strm_state* state);
 void strm_time_init(strm_state* state);
 void strm_math_init(strm_state* state);
 void strm_graph_init(strm_state* state);
+void strm_proc_init(strm_state* state);
 
 void
 strm_init(strm_state* state)
@@ -26,4 +27,5 @@ strm_init(strm_state* state)
   strm_time_init(state);
   strm_math_init(state);
   strm_graph_init(state);
+  strm_proc_init(state);
 }

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,41 @@
+#include "strm.h"
+
+/* TODO: Use sensible values. */
+#define CMD_MAX 100
+
+static int
+proc_spawn(strm_stream* strm, int argc, strm_value* args, strm_value* ret)
+{
+	const char *strcmd;
+	strm_string cmd;
+	char buf[CMD_MAX];
+	FILE *fp;
+	int fd;
+	char *mode;
+	mode = "r+";
+	int strm_mode;
+
+	strm_get_args(strm, argc, args, "S", &cmd);
+	strcmd = strm_str_cstr(cmd, buf);
+
+	fp = popen(strcmd, mode);
+	if (fp == NULL) {
+		strm_raise(strm, "spawn error - popen.");
+		return STRM_NG;
+	}
+
+	fd = fileno(fp);
+	if (fd < 0) return STRM_NG;
+
+	strm_mode = 2; //<- TODO: Use stream's flags.
+	*ret = strm_io_new(fd, strm_mode);
+	return STRM_OK;
+}
+
+void
+strm_proc_init(strm_state* state)
+{
+	// spawn("ls *") | stdout # producer.
+	strm_var_def(state, "spawn", strm_cfunc_value(proc_spawn));
+
+}


### PR DESCRIPTION
Hey @matz, I have an early-stage prototype of the spawn function. 
The code is not meant to be merged, I just want to know what do you think about it.
 
This works:
```
spawn("ls") | stdout                           # can be a producer
```

These don't (yet):
```
stream | spawn("grep foo") | stdout  # and also be a filter
stream | spawn("cat > /tmp/a")         # and a consumer
```

Any feedback would be very welcomed.
