### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: ci
+'on':
+  - push
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        compiler:
+        - gcc
+        - clang
+    steps:
+    - name: Install dependencies
+      run: 'sudo apt install -q ${{ matrix.compiler }} libgc-dev'
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Build and test
+      run: 'make test CC=${{ matrix.compiler }}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-install:
- - sudo apt-get -q install libgc-dev
-language: c
-compiler:
-- clang
-- gcc
-script: make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Streem
-[![Build Status](https://travis-ci.org/matz/streem.svg?branch=master)](https://travis-ci.org/matz/streem)
+[![Build Status](https://github.com/matz/streem/workflows/ci/badge.svg)](https://github.com/matz/streem/actions?query=workflow%3Aci)
 [![Gitter](https://badges.gitter.im/JoinChat.svg)](https://gitter.im/matz/streem?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Streem is a stream based concurrent scripting language. It is based on a


### PR DESCRIPTION
Streem currently uses travis-ci.org for CI, which is shutting down in a few weeks.  Travis asks its users to migrate to travis-ci.com, but travis-ci.com recently had [problems with FOSS project credit](https://news.ycombinator.com/item?id=25338983).  While the problems are resolved, they were not a good sign for the future of the service.  Instead, I suggest migrating to GitHub Actions.